### PR TITLE
Add page mover function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,34 +50,9 @@ jobs:
       - run:
           name: "Build"
           command: "npm run build"
-  node_v8:
-    working_directory: "~/repo"
-    docker:
-      - image: "node:8.16"
-    steps:
-      - "checkout"
-      - restore_cache:
-          key: "node-v8.16-node-modules-{{ checksum \"package.json\" }}"
-      - run:
-          name: "Install packages"
-          command: "npm ci"
-      - save_cache:
-          key: "node-v8.16-node-modules-{{ checksum \"package.json\" }}"
-          paths:
-            - "node_modules"
-      - run:
-          name: "Execute linters"
-          command: "npm run lint"
-      - run:
-          name: "Execute tests"
-          command: "npm test"
-      - run:
-          name: "Build"
-          command: "npm run build"
 workflows:
   version: 2
   build:
     jobs:
       - "node_v12"
       - "node_v10"
-      - "node_v8"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ you can create links type safely.
 
 ## Quick Start
 ### Requirements
-- Node.js 8.0.0 or higher
+- Node.js 10.0.0 or higher
 - npm or Yarn
 - **Next.js 9 or higher**
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ export default () => (
     <a>Go to the user page (id: {targetUserId})</a>
   </Link>
 );
+
+// And it is possible to redirect URL for unviersal (client and server-side)!
+import Router from "next/router";
+import { createPageMover } from "next-typed-routes";
+
+const movePage = createPageMover("https://you-project.example.com", Router);
+
+...
+Component.getInitialProps = async ({ res }) => {
+  // Redirect to `/users/123&limit=30` .
+  // This works fine on web browsers and server-side.
+  movePage(routes.usersDetail(123), { res, queryParameters: { limit: 30 } })
+};
 ```
 
 <div align="center">
@@ -52,8 +65,11 @@ export default () => (
   - [Routes](#routes)
     - [Arguments of `createRoute`](#arguments-of-createroute)
     - [Key names](#key-names)
+  - [Page Mover](#page-mover)
 - [API](#api)
   - [`createRoute(path, parameters, queryParameters): { href: string, as: string }`](#createroutepath-parameters-queryparameters--href-string-as-string-)
+  - [`createPageMover(baseURI, Router): PageMover`](#createpagemoverbaseuri-router-pagemover)
+  - [`movePage(path, options): void`](#movepagepath-options-void)
 - [Contributing to next-typed-routes](#contributing-to-next-typed-routes)
 - [License](#license)
 
@@ -171,6 +187,28 @@ export const routes = {
 You can freely name keys of `routes` , but I recommend you to adopt the same with page file path for key names in order to reduce
 the thinking time to name them.
 
+### Page Mover
+```ts
+import Router from "next/router";
+import { createPageMover } from "next-typed-routes";
+
+const movePage = createPageMover("https://you-project.example.com", Router);
+
+movePage("/about");
+movePage(createRoute("/"));
+```
+
+next-typed-routes provides a function to reidrect to a specific page using `createRoute` . This works fine on cliet-side (web browsers)
+and server-side.
+
+If you want to support server-side, you must give `res` object from `getInitialProps` arguments.
+
+```ts
+Component.getInitialProps = async ({ res }) => {
+  movePage("/about", { res });
+};
+```
+
 
 ## API
 ### `createRoute(path, parameters, queryParameters): { href: string, as: string }`
@@ -183,14 +221,56 @@ createRoute("/users/[userId]/items/[itemId]", { userId: 1, itemId: 2 })
 Returns an object for `<Link>` component props.
 
 - `path: string`
-  - Required.
-  - A page of Next.js. This is a path of files in `/pages` in general.
+  - Required
+  - A page of Next.js. This is a path of files in `/pages` in general
 - `parameters: { [key: string]: number | string | undefined | null }`
-  - Optional, default is `{}` .
-  - You can give dynamic parameters as object.
-- `queryParameters: { [key: string]: number | string | boolean | null | undefined }`
-  - Optional, default is `{}` .
-  - You can give query string as object.
+  - Optional, default is `{}`
+  - You can give dynamic parameters as object
+- `queryParameters: { [key: string]: number | string | boolean | undefined | null }`
+  - Optional, default is `{}`
+  - You can give query string as object
+
+### `createPageMover(baseURI, Router): PageMover`
+```ts
+createPageMover("https://you-project.example.com", Router);
+createPageMover(new URL("https://you-project.example.com"), Router);
+```
+
+Returns a function to redirect URL.
+
+- `baseURI: string | URL`
+  - Required
+  - Your project base URI
+- `Router: NextRouter`
+  - Required
+  - Give Router object from `next/router` in your project
+
+### `movePage(path, options): void`
+```ts
+movePage("/about");
+movePage(createRoute("/about"));
+
+movePage("/about", { res, statusCode: 301 });
+movePage("/about", { res, queryParameters: { limit: 30 } });
+```
+
+This function is created from `createPageMover` .
+
+- `path: string | { href: string, as: string }`
+  - Required
+  - A destination path
+  - It is possible to give a return value from `createRoute`
+- `options: Options`
+  - Optional, default is `{}`
+  - `res: ServerResponse`
+    - Required if you want to support server-side redirect
+    - A sever response object for server-side
+    - It is possible to get a context object which contains this from Next.js `getInitialProps` arguments
+  - `queryParameters: { [key: string]: number | string | boolean | undefined | null }`
+    - An object for query string
+    - If `path` already has query string, it will be merged with `queryParameters`
+  - `statusCode: 301 | 302`
+    - A status code for server-side
 
 
 ## Contributing to next-typed-routes

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,12 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,42 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
@@ -138,6 +174,12 @@
       "version": "12.7.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
       "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -282,6 +324,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "assertion-error": {
@@ -1221,6 +1269,12 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1349,6 +1403,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1415,6 +1475,12 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1609,6 +1675,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -1862,6 +1941,15 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -2093,6 +2181,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {},
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=10.0.0"
   },
   "engineStrict": false,
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/chai": "^4.2.3",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.11",
+    "@types/sinon": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
     "chai": "^4.2.0",
@@ -57,6 +58,7 @@
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "prettier": "^1.18.2",
+    "sinon": "^7.5.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.3",
     "@types/mocha": "^5.2.7",
+    "@types/node": "^12.7.11",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
     "chai": "^4.2.0",

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -1,0 +1,1 @@
+export type QueryParameters = Record<string, number | string | boolean | undefined | null>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./page-mover";
 export * from "./route-creator";

--- a/src/page-mover.spec.ts
+++ b/src/page-mover.spec.ts
@@ -1,0 +1,237 @@
+import { ServerResponse } from "http";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { createPageMover } from "./page-mover";
+
+describe("page-mover.ts", function() {
+  const dummyBaseURL = new URL("https://example.com");
+  let routerPushSpy: sinon.SinonSpy;
+  let dummyRouter: { push: (url: string, as?: string, options?: {}) => Promise<boolean> };
+  let resWriteHeadSpy: sinon.SinonSpy;
+  let resEndSpy: sinon.SinonSpy;
+  let dummyRes: ServerResponse;
+
+  beforeEach(function() {
+    routerPushSpy = sinon.spy();
+    dummyRouter = { push: routerPushSpy };
+
+    resWriteHeadSpy = sinon.spy();
+    resEndSpy = sinon.spy();
+    dummyRes = {
+      writeHead: resWriteHeadSpy,
+      end: resEndSpy,
+    } as any;
+  });
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  context("when specifying a path as string,", function() {
+    const dummyPath = "/foo/bar";
+
+    context("without a res object,", function() {
+      it("should call `Router.push` with the path", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath);
+
+        expect(routerPushSpy.calledOnceWithExactly(dummyPath, dummyPath)).to.be.true;
+      });
+
+      it("should not use a res object", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath);
+
+        expect(resWriteHeadSpy.notCalled).to.be.true;
+        expect(resEndSpy.notCalled).to.be.true;
+      });
+
+      context("specifying `options.queryParameters`,", function() {
+        context("a path does not have query string,", function() {
+          it("should call `Router.push` with the parameters as query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(dummyPath, { queryParameters: { a: 1, b: "2" } });
+
+            expect(routerPushSpy.calledOnceWithExactly(`${dummyPath}?a=1&b=2`, `${dummyPath}?a=1&b=2`)).to.be.true;
+          });
+        });
+
+        context("a path has query string,", function() {
+          it("should call `Router.push` with merge query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(`${dummyPath}?x=1&y=2`, { queryParameters: { a: 1, b: "2" } });
+
+            expect(
+              routerPushSpy.calledOnceWithExactly(`${dummyPath}?a=1&b=2&x=1&y=2`, `${dummyPath}?a=1&b=2&x=1&y=2`),
+            ).to.be.true;
+          });
+        });
+      });
+    });
+
+    context("with a res object,", function() {
+      it("should not use `Router`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(routerPushSpy.notCalled).to.be.true;
+      });
+
+      it("should call `res.writeHead` with the string as object", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(
+          resWriteHeadSpy.calledOnceWithExactly(302, { Location: new URL(dummyPath, dummyBaseURL).toString() }),
+        ).to.be.true;
+      });
+
+      it("should call `res.end`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(resEndSpy.calledOnce).to.be.true;
+      });
+
+      context("specifying `options.statusCode`,", function() {
+        it("should call `res.writeHead` with the string and the status code", function() {
+          const statusCode = 301;
+
+          const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+          moveToPage(dummyPath, { statusCode, res: dummyRes });
+
+          expect(
+            resWriteHeadSpy.calledOnceWithExactly(statusCode, { Location: new URL(dummyPath, dummyBaseURL).toString() }),
+          ).to.be.true;
+        });
+      });
+
+      context("specifying `options.queryParameters`,", function() {
+        context("a path does not have query string,", function() {
+          it("should call `res.writeHead` with the parameters as query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(dummyPath, { res: dummyRes, queryParameters: { a: 1, b: "2" } });
+
+            const url = new URL(`${dummyPath}?a=1&b=2`, dummyBaseURL);
+            expect(resWriteHeadSpy.calledOnceWithExactly(302, { Location: url.toString() })).to.be.true;
+          });
+        });
+
+        context("a path has query string,", function() {
+          it("should call `res.writeHead` with merge query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(`${dummyPath}?x=1&y=2`, { res: dummyRes, queryParameters: { a: 1, b: "2" } });
+
+            const url = new URL(`${dummyPath}?a=1&b=2&x=1&y=2`, dummyBaseURL);
+            expect(resWriteHeadSpy.calledOnceWithExactly(302, { Location: url.toString() })).to.be.true;
+          });
+        });
+      });
+    });
+  });
+
+  context("when specifying a path as returned value from `createRoute`,", function() {
+    const dummyPath = { href: "/users/[userId]", as: "/users/123" };
+
+    context("without a res object,", function() {
+      it("should call `Router.push` with the path's `href` and `as`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath);
+
+        expect(routerPushSpy.calledOnceWithExactly(dummyPath.href, dummyPath.as)).to.be.true;
+      });
+
+      it("should not use a res object", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath);
+
+        expect(resWriteHeadSpy.notCalled).to.be.true;
+        expect(resEndSpy.notCalled).to.be.true;
+      });
+
+      context("specifying `options.queryParameters`,", function() {
+        context("a path does not have query string,", function() {
+          it("should call `Router.push` with the parameters as query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(dummyPath, { queryParameters: { a: 1, b: "2" } });
+
+            expect(routerPushSpy.calledOnceWithExactly(`${dummyPath.href}?a=1&b=2`, `${dummyPath.as}?a=1&b=2`)).to.be.true;
+          });
+        });
+
+        context("a path has query string,", function() {
+          it("should call `Router.push` with merge query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            const path = { href: "/users/[userId]?limit=30", as: "/users/123?limit=30" };
+            moveToPage(path, { queryParameters: { a: 1, b: "2" } });
+
+            expect(
+              routerPushSpy.calledOnceWithExactly("/users/[userId]?a=1&b=2&limit=30", "/users/123?a=1&b=2&limit=30"),
+            ).to.be.true;
+          });
+        });
+      });
+    });
+
+    context("with a res object,", function() {
+      it("should not use `Router`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(routerPushSpy.notCalled).to.be.true;
+      });
+
+      it("should call `res.writeHead` with the path's `as`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(
+          resWriteHeadSpy.calledOnceWithExactly(302, { Location: new URL(dummyPath.as, dummyBaseURL).toString() }),
+        ).to.be.true;
+      });
+
+      it("should call `res.end`", function() {
+        const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+        moveToPage(dummyPath, { res: dummyRes });
+
+        expect(resEndSpy.calledOnce).to.be.true;
+      });
+
+      context("specifying `options.statusCode`,", function() {
+        it("should call `res.writeHead` with the string and the status code", function() {
+          const statusCode = 301;
+
+          const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+          moveToPage(dummyPath, { statusCode, res: dummyRes });
+
+          expect(
+            resWriteHeadSpy.calledOnceWithExactly(statusCode, { Location: new URL(dummyPath.as, dummyBaseURL).toString() }),
+          ).to.be.true;
+        });
+      });
+
+      context("specifying `options.queryParameters`,", function() {
+        context("a path does not have query string,", function() {
+          it("should call `res.writeHead` with the parameters as query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            moveToPage(dummyPath, { res: dummyRes, queryParameters: { a: 1, b: "2" } });
+
+            const url = new URL(`${dummyPath.as}?a=1&b=2`, dummyBaseURL);
+            expect(resWriteHeadSpy.calledOnceWithExactly(302, { Location: url.toString() })).to.be.true;
+          });
+        });
+
+        context("a path has query string,", function() {
+          it("should call `res.writeHead` with merge query string", function() {
+            const moveToPage = createPageMover(dummyBaseURL, dummyRouter);
+            const path = { href: "/users/[userId]?limit=30", as: "/users/123?limit=30" };
+            moveToPage(path, { res: dummyRes, queryParameters: { a: 1, b: "2" } });
+
+            const url = new URL("/users/123?a=1&b=2&limit=30", dummyBaseURL);
+            expect(resWriteHeadSpy.calledOnceWithExactly(302, { Location: url.toString() })).to.be.true;
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/page-mover.ts
+++ b/src/page-mover.ts
@@ -1,0 +1,59 @@
+import { ServerResponse } from "http";
+
+import { QueryParameters } from "./common-types";
+import { mergeQueryString } from "./query-merger";
+import { createRoute } from "./route-creator";
+
+type Router = {
+  push: (url: string, as?: string, options?: {}) => Promise<boolean>;
+};
+
+type Options = Partial<{
+  /**
+   * A sever response object for server-side.
+   * It is possible to get a context object which contains this from Next.js `getInitialProps` arguments.
+   */
+  res: ServerResponse;
+  /** An object for query string. */
+  queryParameters: QueryParameters;
+  /** A status code for server-side */
+  statusCode: 301 | 302;
+}>;
+
+export const createPageMover = (
+  /** A base URI of project. */
+  baseURI: string | URL,
+  /** Next.js built-in router object. */
+  Router: Router,
+) => (
+  /** A destination absolute path or return value from `createRoute` function. */
+  path: string | ReturnType<typeof createRoute>,
+  /**
+   * Options.
+   * @default {}
+   */
+  options: Options = {},
+) => {
+  const uri = typeof path === "string" ? path : path.href;
+  const alias = typeof path === "string" ? path : path.as;
+
+  const res = options.res;
+  if (res == undefined) {
+    // For client.
+    if (options.queryParameters == undefined) return Router.push(uri, alias);
+
+    const pageURL = new URL(uri, baseURI);
+    const aliasURL = new URL(alias, baseURI);
+    const pageQueryString = mergeQueryString(pageURL, options.queryParameters);
+    const aliasQueryString = mergeQueryString(aliasURL, options.queryParameters);
+
+    return Router.push(`${pageURL.pathname}?${pageQueryString}`, `${aliasURL.pathname}?${aliasQueryString}`);
+  }
+
+  // For server.
+  const aliasURL = new URL(alias, baseURI);
+  const queryString = mergeQueryString(aliasURL, options.queryParameters || {});
+  const url = new URL(queryString.length > 0 ? `${aliasURL.pathname}?${queryString}` : alias, baseURI);
+  res.writeHead(options.statusCode || 302, { Location: url.toString() });
+  res.end();
+};

--- a/src/query-merger.spec.ts
+++ b/src/query-merger.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from "chai";
+
+import { mergeQueryString } from "./query-merger";
+
+describe("query-merger.ts", function() {
+  it("should merge query strings", function() {
+    expect(mergeQueryString(new URL("https://foo.example.com/"), {})).to.eq("");
+    expect(mergeQueryString(new URL("https://foo.example.com/"), { a: 1, b: "2" })).to.eq("a=1&b=2");
+
+    expect(mergeQueryString(new URL("https://foo.example.com/bar?x=1&y=2"), {})).to.eq("x=1&y=2");
+    expect(mergeQueryString(new URL("https://foo.example.com/bar?x=1&y=2"), { a: 1, b: "2" })).to.eq("a=1&b=2&x=1&y=2");
+  });
+});

--- a/src/query-merger.ts
+++ b/src/query-merger.ts
@@ -1,0 +1,9 @@
+import * as queryString from "query-string";
+
+import { QueryParameters } from "./common-types";
+
+export const mergeQueryString = (url: URL, queryParameters: QueryParameters) =>
+  queryString.stringify({
+    ...queryString.parse(url.search),
+    ...queryParameters,
+  });

--- a/src/route-creator.ts
+++ b/src/route-creator.ts
@@ -1,5 +1,7 @@
 import * as queryString from "query-string";
 
+import { QueryParameters } from "./common-types";
+
 export const createRoute = (
   /** A page of Next.js. This is a path of files in `/pages` in general. */
   path: string,
@@ -12,7 +14,7 @@ export const createRoute = (
    * An object for query string.
    * @default {}
    */
-  queryParameters: Record<string, number | string | boolean | null | undefined> = {},
+  queryParameters: QueryParameters = {},
 ) => {
   const pagePath = path.replace(/^\/*/, "/");
   const completedURISegments: string[] = [];


### PR DESCRIPTION
# New Features
- Install "@types/node" package
- Install "sinon" package
- Define QueryParameters type
- Add `mergeQueryString` function
- Add `createPageMover` function


# Changes and Fixes
- Update a readme
- Drop support for Node.js 8
  - Because `URL` object is undefined in the global
